### PR TITLE
JwtBearerMiddlewareDiagnostics updated from singleton to transient to resolve conflicts in case of multiple authentication schemas

### DIFF
--- a/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
+++ b/src/Microsoft.Identity.Web/WebApiExtensions/MicrosoftIdentityWebApiAuthenticationBuilderExtensions.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Identity.Web
 
             if (subscribeToJwtBearerMiddlewareDiagnosticsEvents)
             {
-                builder.Services.AddSingleton<IJwtBearerMiddlewareDiagnostics, JwtBearerMiddlewareDiagnostics>();
+                builder.Services.AddTransient<IJwtBearerMiddlewareDiagnostics, JwtBearerMiddlewareDiagnostics>();
             }
 
             // Change the authentication configuration to accommodate the Microsoft identity platform endpoint (v2.0).


### PR DESCRIPTION
In the case of multiple schemas, if the diagnostics is enabled, the events of the last one overwrite the others